### PR TITLE
add Upsert Block Support

### DIFF
--- a/example/resolvers.ts
+++ b/example/resolvers.ts
@@ -1,5 +1,5 @@
-import { extraction } from '../src';
-import { doQuery, doMutation } from './utils/main';
+import { extraction, mountUpsert } from '../src';
+import { doQuery, doMutation, doUpsert } from './utils/main';
 
 const reservedList = {
 	reverse: ['friend @reverse']
@@ -9,7 +9,9 @@ export default {
 	Query: {
 		getAlice: async (parent: any, args: any, context: any, resolveInfo: any) => {
 			const query = extraction(resolveInfo, args, context, reservedList);
-			return await doQuery({ query }).then(res => {
+			let dgraphQuery = query[0];
+			return await doQuery({ query: dgraphQuery }).then(res => {
+				console.log(query[1]);
 				return res.getAlice;
 			});
 		}
@@ -23,6 +25,13 @@ export default {
 		addPerson: async (parent: any, args: any, context: any, resolveInfo: any) => {
 			console.log(args.input); // Create here your way to resolve this mutation
 			return false;
+		},
+		upsertUser: async (parent: any, args: any, context: any, resolveInfo: any) => {
+			const query: any = extraction(resolveInfo, args, context, reservedList);
+			let upsert = mountUpsert(args, query);
+			return await doUpsert(upsert, query[1]).then((res: any) => {
+				return res.upsertUser[0];
+			});
 		}
 	}
 };

--- a/example/resolvers.ts
+++ b/example/resolvers.ts
@@ -11,7 +11,6 @@ export default {
 			const query = extraction(resolveInfo, args, context, reservedList);
 			let dgraphQuery = query[0];
 			return await doQuery({ query: dgraphQuery }).then(res => {
-				console.log(query[1]);
 				return res.getAlice;
 			});
 		}

--- a/example/schema.graphql
+++ b/example/schema.graphql
@@ -1,9 +1,11 @@
 directive @reverse on FIELD | FIELD_DEFINITION
 directive @filter(func: String) on FIELD | FIELD_DEFINITION
 directive @facets(aliases: String) on FIELD | FIELD_DEFINITION
+directive @var(val: String) on FIELD | FIELD_DEFINITION
 
 type Person {
-	id: String
+	id: String @var
+	email: String @reverse
 	name: String @facets
 	mobile: String
 	mobile_since: String @facets
@@ -45,7 +47,15 @@ input RDF {
 	payload: String
 }
 
+input upsertUserInput {
+	uid: String
+	name: String
+	email: String
+	dgraph_type: String
+}
+
 type Mutation {
 	addDataset(input: RDF): String
 	addPerson(input: [PersonInput]): String
+	upsertUser(func: String, type: String, input: upsertUserInput!): Person @filter
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "weasel-dgraph",
-	"version": "0.2.2",
+	"version": "0.2.8",
 	"description": "A direct GraphQL \"converter\" to Dgraph's `GraphQL+-` language.",
 	"main": "lib/index.js",
 	"type": "lib",

--- a/src/ASTUtils/directives.ts
+++ b/src/ASTUtils/directives.ts
@@ -53,6 +53,7 @@ export default (fieldNode: any) => {
 		const { directives, name, level } = directive;
 
 		const isFacet = directives.filter((e: any) => e.name.value === 'facets')[0];
+		const isVal = directives.filter((e: any) => e.name.value === 'var')[0];
 
 		switch (true) {
 			case !!isFacet: // Case isFacet isn't false
@@ -66,6 +67,13 @@ export default (fieldNode: any) => {
 					name
 				});
 
+				break;
+			case !!isVal:
+				listDirectives.push({
+					arguments: `${directives[0].arguments[0].value.value}`,
+					level,
+					name
+				});
 				break;
 			default:
 				console.log("Some error I think, don't you?");

--- a/src/ASTUtils/treatQuery.ts
+++ b/src/ASTUtils/treatQuery.ts
@@ -1,27 +1,38 @@
 export default (args: any, obj: any, reservedList: any, listDirectives: any) => {
 	let theQuery = obj.body;
 
-	let facetsPattern = /\@facets\([^\n]+\)/gim;
-	let ReversePattern = /\@reverse/gim;
+	const ValPattern = /\@var\([^\n]+\)/gim;
+	const facetsPattern = /\@facets\([^\n]+\)/gim;
+	const ReversePattern = /\@reverse/gim;
+	const UIDpatterns = [' id \n', ' id\n', 'id @var'];
+	const UIDRegex = new RegExp(UIDpatterns.join('|'), 'g');
 	let bodyPattern =
 		(!!args && !!args.reverse) || !!args.dgraph ? /\{[^)]+\}/gim : /\ {[^)]+\}/gim;
 
+	const hasVal = (theQuery: string) => (theQuery.match(ValPattern) ? true : false);
 	const hasFacets = (theQuery: string) => (theQuery.match(facetsPattern) ? true : false);
 	const hasReverse = (theQuery: string) => (theQuery.match(ReversePattern) ? true : false);
+	const hasUID = (theQuery: string) => (theQuery.match(UIDRegex) ? true : false);
 
+	let checkVal: boolean = hasVal(theQuery);
 	let checkReverse: boolean = hasReverse(theQuery);
 	let checkFacets: boolean = hasFacets(theQuery);
+	let checkUID: boolean = hasUID(theQuery);
 
-	function resolveFacets(obj: any) {
+	function cleanFacets(obj: any) {
 		if (checkFacets) {
 			theQuery = obj.replace(facetsPattern, '');
 		}
 	}
-
+	function cleanVal(obj: any) {
+		if (checkVal) {
+			theQuery = obj.replace(ValPattern, ``);
+		}
+	}
 	function resolveReverse(obj: any) {
 		// Todo: This is pretty "hacky". Need a better design.
 		try {
-			const patterns = checkReverse ? [...reservedList.reverse, ' id\n'] : [' id\n'];
+			const patterns = [...reservedList.reverse, ' id \n', ' id\n', ' @reverse'];
 			const regex = new RegExp(patterns.join('|'), 'g');
 			let allMatchs: any = obj.match(regex);
 			let uniqueMatchs: any = allMatchs.filter(
@@ -30,13 +41,9 @@ export default (args: any, obj: any, reservedList: any, listDirectives: any) => 
 			uniqueMatchs
 				? uniqueMatchs.forEach((e: any) => {
 						let regex = new RegExp(e, 'g');
-						var cleanReverseTag = e.replace(/ @reverse/gi, '');
-						obj = obj.replace(
-							regex,
-							e !== ' id\n'
-								? `${cleanReverseTag} : ~${cleanReverseTag}`
-								: `id : uid \n`
-						);
+						let rev = / @reverse/gi;
+						var cleanReverseTag = e.replace(rev, '');
+						obj = obj.replace(regex, `${cleanReverseTag} : ~${cleanReverseTag}`);
 				  })
 				: null;
 		} catch {
@@ -44,15 +51,65 @@ export default (args: any, obj: any, reservedList: any, listDirectives: any) => 
 		}
 		return obj;
 	}
-	resolveFacets(theQuery);
+	function resolveUID(obj: any) {
+		// Todo: This is pretty "hacky". Need a better design.
+		try {
+			let allMatchs: any = obj.match(UIDRegex);
+			let uniqueMatchs: any = allMatchs.filter(
+				(item: any, pos: any) => allMatchs.indexOf(item) == pos
+			);
+			uniqueMatchs
+				? uniqueMatchs.forEach((e: any) => {
+						let regex = new RegExp(e, 'g');
+						switch (true) {
+							case e === ' id \n':
+								obj = obj.replace(regex, `id : uid \n`);
+								break;
+							case e === ' id\n':
+								obj = obj.replace(regex, `id : uid \n`);
+								//obj = obj.replace(regex, `v as id : uid \n`);
+								break;
+							default:
+								return;
+						}
+				  })
+				: null;
+		} catch {
+			return obj;
+		}
+		return obj;
+	}
+
+	cleanFacets(theQuery);
+	cleanVal(theQuery);
 
 	let extractBody = theQuery.match(bodyPattern);
+
 	let exBody = extractBody[1] ? extractBody[1] : extractBody[0];
 
-	listDirectives.forEach((element: any) => {
-		let regex = new RegExp(`${element.name} `, 'g');
-		exBody = exBody.replace(regex, `${element.name} ${element.directive}`);
-	});
+	checkReverse ? (exBody = resolveReverse(exBody)) : null;
 
-	return resolveReverse(exBody);
+	checkUID ? (exBody = resolveUID(exBody)) : null;
+
+	let cleanBody = exBody;
+	const test = /id : uid/gim;
+
+	listDirectives
+		? listDirectives.forEach((element: any) => {
+				switch (true) {
+					case checkVal: // Case isFacet isn't false
+						let regex = new RegExp(` ${element.name} `, 'g');
+						exBody = exBody.replace(regex, `${element.arguments} as ${element.name} `);
+						break;
+					default:
+						let defaultregex = new RegExp(`${element.name} `, 'g');
+						exBody = exBody.replace(
+							defaultregex,
+							`${element.name} ${element.directive}`
+						);
+				}
+		  })
+		: null;
+
+	return { exBody, cleanBody };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,29 @@ export const extraction = (resolveInfo: any, args: any, context: any, reservedLi
 
 	const rootQuery = treatRoot(args, fieldName, rootDirectives);
 	const queryBody = iterate(fieldNode);
+
 	const listDirectives = checkForDirectives(fieldNode);
 
 	const query = _treat(args, queryBody, reservedList, listDirectives);
 
-	return `${rootQuery} ${query}`;
+	let exBody = `${rootQuery} ${query.exBody}`;
+	let cleanBody = `${rootQuery} ${query.cleanBody}`;
+
+	return [exBody, cleanBody];
+};
+
+export const mountUpsert = (args: any, query: any) => {
+	let a = JSON.stringify(args.input);
+	let b = JSON.stringify(query[0]);
+
+	const dtype = /dgraph.type/gim;
+	const last = /"}/gim;
+	const hasdtype = (theQuery: string) => (theQuery.match(dtype) ? true : false);
+	let checkdtype: boolean = hasdtype(a);
+
+	if ('type' in args && !checkdtype) {
+		'emailG' in args.input ? null : (a = a.replace(last, `","dgraph.type":${args.type}}`));
+	}
+
+	return `{"query": ${b},"set": ${a}}`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,11 @@ export const mountUpsert = (args: any, query: any) => {
 	let checkdtype: boolean = hasdtype(a);
 
 	if ('type' in args && !checkdtype) {
-		'emailG' in args.input ? null : (a = a.replace(last, `","dgraph.type":${args.type}}`));
+		'dgraph_type' in args.input ? null : (a = a.replace(last, `","dgraph.type":${args.type}}`));
+	}
+
+	if ('type' in args === false && !checkdtype) {
+		'dgraph.type' in args.input ? null : (a = a.replace(last, `","dgraph.type": "unknown"}`));
 	}
 
 	return `{"query": ${b},"set": ${a}}`;


### PR DESCRIPTION
This adds support for Upsert using Mutation operation.

Type is mandatory in Upserts, if the user doesn't provide dgraph_type, it will try to insert one. Which in case of no type given it will be `"dgraph.type": "unknown"`.

ref: https://github.com/MichelDiz/Weasel/issues/18